### PR TITLE
allow foreign tables without pid=0

### DIFF
--- a/system/modules/pct_tabletree_widget/PCT/Widgets/TableTree/TableTree.php
+++ b/system/modules/pct_tabletree_widget/PCT/Widgets/TableTree/TableTree.php
@@ -290,7 +290,8 @@ class TableTree extends \Contao\Widget
 			{
 				// check if table contains a pid field
 				$hasPid = false;
-				if($objDatabase->fieldExists('pid',$this->strSource)  && in_array( (int)$GLOBALS['TL_DCA'][$this->strSource]['list']['sorting']['mode'], array(4,5) ) )
+				$hasRootNode = ($objDatabase->prepare("SELECT pid FROM ".$this->strSource." WHERE pid=0")->execute()->numRows > 0);
+				if($hasRootNode && $objDatabase->fieldExists('pid',$this->strSource)  && in_array( (int)$GLOBALS['TL_DCA'][$this->strSource]['list']['sorting']['mode'], array(4,5) ) )
 				{
 					$hasPid = true;
 				}


### PR DESCRIPTION
Bei Kindtabellen (Mode 4) gibt es nicht zwingend ein pid=0. In diesen Fällen werden beim Attribut "tags" keine Elemente angezeigt. Durch eine einfache Abfrage kann das aber analog der Suche trotzdem ermöglicht werden. Im TableTree wird ja explizit auf Mode 4 (und 5) geprüft. Aber wenn auf Mode 4 geprüft wird, sollte auch die Prüfung stattfinden, ob es überhaupt pid=0 gibt - da es sonst meiner Meinung nach nicht richtig wäre?

Dein Argument ist, dass das in der Liste aber sehr unübersichtlich wird, weil es keine Informationen über die Eltern gibt bzw. das ganze sehr unperformant, weil jedes Kind jeweils ein Query auslösen würde auf sein Elternteil. Und Deiner Meinung nach erlaubt das die Baumdarstellung erlaubt ebenfalls nicht.

Letztlich würde es sich aber genauso verhalten wie die Suche. Auch hier gibt es ja keine Abfrage auf den pid=0. In der aktuellen Version klappt ja alles, nur werden im TableTree nur Einträge über die Suche angezeigt. Warum dann nicht auch ohne Suche für den Fall, das pid=0 ist? Also im TableTree konnte ich im Vergleich zur Suche keine zusätzlichen Queries feststellen.