### PR TITLE
Fix "Undefined array key" warning in TableTree session node check (Contao 5.7)

### DIFF
--- a/system/modules/pct_tabletree_widget/PCT/Widgets/TableTree/TableTree.php
+++ b/system/modules/pct_tabletree_widget/PCT/Widgets/TableTree/TableTree.php
@@ -255,9 +255,10 @@ class TableTree extends \Contao\Widget
 			$strNode = $objSession->get('tabletree_node');
 			
 			// Unset the node if it is not within the predefined node set (see #5899)
-			if ($strNode > 0 && is_array($GLOBALS['TL_DCA'][$this->strSource]['fields'][$this->strField][$this->strRootField]))
+			// The field is defined in the DCA of strTable, not strSource
+			if ($strNode > 0 && is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField][$this->strRootField] ?? null))
 			{
-				if (!in_array($strNode, $objDatabase->getChildRecords($GLOBALS['TL_DCA'][$this->strSource]['fields'][$this->strField][$this->strRootField], $this->strSource)))
+				if (!in_array($strNode, $objDatabase->getChildRecords($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField][$this->strRootField], $this->strSource)))
 				{
 					$objSession->remove('tabletree_node');
 				}


### PR DESCRIPTION
The predefined-node-set check in `TableTree::generate()` reads the field definition from `$GLOBALS['TL_DCA'][$this->strSource]`, but the field is defined in the DCA of `strTable` (the elseif below and Contao core's PageSelector both use `strTable`).

**Reproduce (2.0.3, Contao 5.7.9, PHP 8.4):**
1. Open the tags backend module and click into a branch — `addBreadcrumb()` stores `tabletree_node` in the session
2. Open any tabletree/tags picker in a record edit view
3. → `Warning: Undefined array key "<fieldname>" at TableTree.php:258` (surfaces as a visible error in the Contao 5 backend; reported in support ticket #35870, customer on Contao 5.7 / CustomCatalog)

**Fix:** read the root-field definition from `strTable` with a null-safe guard. Verified against Contao 5.7.9: same reproduction steps, warning gone, picker renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)